### PR TITLE
Force SIP URI and TLS Transport

### DIFF
--- a/app/src/main/java/org/linphone/core/CoreContext.kt
+++ b/app/src/main/java/org/linphone/core/CoreContext.kt
@@ -717,16 +717,18 @@ class CoreContext(
         if (corePreferences.sendEarlyMedia) {
             params.isEarlyMediaSendingEnabled = true
         }
-        val stringAddress: String = address.asString().replace("sip:", "sips:")
+
+        val stringAddress: String = address.asString().replace("sips:", "sip:")
         val newAddress: Address? = core.interpretUrl(stringAddress, LinphoneUtils.applyInternationalPrefix())
         if (newAddress == null) {
             Log.e("[Context] Failed to parse $stringAddress, abort outgoing call")
             callErrorMessageResourceId.value = Event(context.getString(R.string.call_error_network_unreachable))
             return
-        } else {
-            val call = core.inviteAddressWithParams(newAddress, params)
-            Log.i("[Context] Starting call $call")
         }
+        newAddress.transport = TransportType.Tls
+
+        val call = core.inviteAddressWithParams(newAddress, params)
+        Log.i("[Context] Starting call $call")
     }
 
     fun switchCamera() {


### PR DESCRIPTION
Per Belledonne recommendation, this forces outbound URIs to use `sip` scheme and add `;transport=tls` to the end of the URI.